### PR TITLE
Add --webextension option to command line

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const program = new commander.Command(packageFile.name)
     'override default page like New Tab, Bookmarks, or History page'
   )
   .option('--devtools', 'add features to Chrome Developer Tools')
+  .option('--webextension', `create a cross-rowser compatible WebExtension with ${chalk.blue(webextension-polyfill)}`)
   .on('--help', () => {
     console.log(`    Only ${chalk.green('<project-directory>')} is required.`);
   })


### PR DESCRIPTION
The --webextension option will automatically add webextension-polyfill to your extension by default as discussed in #1 

Please don't merge this PR yet.