### PR TITLE
Add support for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ chrome-extension-cli my-extension --override-page=history      // Override Histo
 
 Creates a Panel inside developer tools.
 
-### `chrome-extension-cli my-extension --typescript`
+#### `chrome-extension-cli my-extension --typescript`
 
 Generates an extension with TypeScript in place of JavaScript
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ my-extension
 │   └── manifest.json
 └── src
     ├── *.css                 // CSS files will vary depending on extension type
-    └── *.js                  // JS files will vary depending on extension type
+    └── *.js                  // JS files will vary depending on extension type (.ts eventually)
 ```
 
 Once the installation is done, you can open your project folder:
@@ -170,6 +170,10 @@ chrome-extension-cli my-extension --override-page=history      // Override Histo
 #### `chrome-extension-cli my-extension --devtools`
 
 Creates a Panel inside developer tools.
+
+### `chrome-extension-cli my-extension --typescript`
+
+Generates an extension with TypeScript in place of JavaScript
 
 ## Contributing
 

--- a/config/typescript/paths.js
+++ b/config/typescript/paths.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const path = require('path');
+
+const PATHS = {
+  src: path.resolve(__dirname, '../src'),
+  build: path.resolve(__dirname, '../build'),
+};
+
+module.exports = PATHS;

--- a/config/typescript/webpack.common.js
+++ b/config/typescript/webpack.common.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const SizePlugin = require('size-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { CheckerPlugin } = require('awesome-typescript-loader');
+
+const PATHS = require('./paths');
+
+// To re-use webpack configuration across templates,
+// CLI maintains a common webpack configuration file - `webpack.common.js`.
+// Whenever user creates an extension, CLI adds `webpack.common.js` file
+// in template's `config` folder
+const common = {
+  output: {
+    // the build folder to output bundles and assets in.
+    path: PATHS.build,
+    // the filename template for entry chunks
+    filename: '[name].js',
+  },
+  devtool: 'source-map',
+  stats: {
+    all: false,
+    errors: true,
+    builtAt: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: 'awesome-typescript-loader'
+      },
+      // Help webpack in understanding CSS files imported in .js files
+      {
+        test: /\.css$/,
+        use: [MiniCssExtractPlugin.loader, 'css-loader'],
+      },
+      // Check for images imported in .js files and
+      {
+        test: /\.(png|jpe?g|gif)$/i,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              outputPath: 'images',
+              name: '[name].[ext]',
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new CheckerPlugin(),
+    // Print file sizes
+    new SizePlugin(),
+    // Copy static assets from `public` folder to `build` folder
+    new CopyWebpackPlugin([
+      {
+        from: '**/*',
+        context: 'public',
+      },
+    ]),
+    // Extract CSS into separate files
+    new MiniCssExtractPlugin({
+      filename: '[name].css',
+    }),
+  ],
+};
+
+module.exports = common;

--- a/templates/devtools/config/webpack.config.js
+++ b/templates/devtools/config/webpack.config.js
@@ -8,9 +8,12 @@ const PATHS = require('./paths');
 // Merge webpack configuration files
 const config = merge(common, {
   entry: {
-    devtools: PATHS.src + '/devtools.js',
-    panel: PATHS.src + '/panel.js',
-    background: PATHS.src + '/background.js',
+    devtools: PATHS.src + '/devtools',
+    panel: PATHS.src + '/panel',
+    background: PATHS.src + '/background',
+  },
+  resolve: {
+    extensions: ['.js', '.ts'],
   },
 });
 

--- a/templates/override-page/config/webpack.config.js
+++ b/templates/override-page/config/webpack.config.js
@@ -8,8 +8,11 @@ const PATHS = require('./paths');
 // Merge webpack configuration files
 const config = merge(common, {
   entry: {
-    app: PATHS.src + '/app.js',
-    background: PATHS.src + '/background.js',
+    app: PATHS.src + '/app',
+    background: PATHS.src + '/background',
+  },
+  resolve: {
+    extensions: ['.js', '.ts'],
   },
 });
 

--- a/templates/popup/config/webpack.config.js
+++ b/templates/popup/config/webpack.config.js
@@ -8,9 +8,12 @@ const PATHS = require('./paths');
 // Merge webpack configuration files
 const config = merge(common, {
   entry: {
-    popup: PATHS.src + '/popup.js',
-    contentScript: PATHS.src + '/contentScript.js',
-    background: PATHS.src + '/background.js',
+    popup: PATHS.src + '/popup',
+    contentScript: PATHS.src + '/contentScript',
+    background: PATHS.src + '/background',
+  },
+  resolve: {
+    extensions: ['.js', '.ts'],
   },
 });
 

--- a/templates/popup/src/contentScript.js
+++ b/templates/popup/src/contentScript.js
@@ -12,32 +12,34 @@
 // See https://developer.chrome.com/extensions/content_scripts
 
 // Log `title` of current active web page
-const pageTitle = document.head.getElementsByTagName('title')[0].innerHTML;
-console.log(
-  `Page title is: '${pageTitle}' - evaluated by Chrome extension's 'contentScript.js' file`
-);
+(function () {
+  const pageTitle = document.head.getElementsByTagName('title')[0].innerHTML;
+  console.log(
+    `Page title is: '${pageTitle}' - evaluated by Chrome extension's 'contentScript.js' file`
+  );
 
-// Communicate with background file by sending a message
-chrome.runtime.sendMessage(
-  {
-    type: 'GREETINGS',
-    payload: {
-      message: 'Hello, my name is Con. I am from ContentScript.',
+  // Communicate with background file by sending a message
+  chrome.runtime.sendMessage(
+    {
+      type: 'GREETINGS',
+      payload: {
+        message: 'Hello, my name is Con. I am from ContentScript.',
+      },
     },
-  },
-  response => {
-    console.log(response.message);
-  }
-);
+    response => {
+      console.log(response.message);
+    }
+  );
 
-// Listen for message
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.type === 'COUNT') {
-    console.log(`Current count is ${request.payload.count}`);
-  }
+  // Listen for message
+  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.type === 'COUNT') {
+      console.log(`Current count is ${request.payload.count}`);
+    }
 
-  // Send an empty response
-  // See https://github.com/mozilla/webextension-polyfill/issues/130#issuecomment-531531890
-  sendResponse({});
-  return true;
-});
+    // Send an empty response
+    // See https://github.com/mozilla/webextension-polyfill/issues/130#issuecomment-531531890
+    sendResponse({});
+    return true;
+  });
+})();

--- a/templates/popup/src/popup.js
+++ b/templates/popup/src/popup.js
@@ -29,7 +29,7 @@ import './popup.css';
   };
 
   function setupCounter(initialValue = 0) {
-    document.getElementById('counter').innerHTML = initialValue;
+    document.getElementById('counter').innerHTML = initialValue.toString();
 
     document.getElementById('incrementBtn').addEventListener('click', () => {
       updateCounter({


### PR DESCRIPTION
Hi,

When I found out that there is a type definition for chrome extensions, I started using it and now I can't go back. For this reason I used to generate the extension with this useful cli and, then, tweak the configuration to add the support for TypeScript.

After some time, I decided to implement a `--typescript` flag in a fork of the project and, now, I decided to open a pull request since it can be useful for all the people that are struggling with a chrome extension, and could like a help in guessing the right symbol.

The changes are meant to be the least invasive possible. In the `webpack.config.js` the extensions are disappeared from the `entry` object, and it has been introduced a `resolve.extensions` property to look for `js` files first and `ts` files later.

The config has been duplicated in order to have two independent configurations for typescript and not-typescript configurations.

Few JavaScript files have been modified in the `template` folder in order to be fine also with TypeScript.

Let me know if the proposal is useful. Thank you